### PR TITLE
Edit pages for employee and shifts

### DIFF
--- a/app/dashboard/components/edit-employees.tsx
+++ b/app/dashboard/components/edit-employees.tsx
@@ -1,0 +1,209 @@
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useFieldArray, useForm } from "react-hook-form";
+
+//shadcn
+import { Input } from '@/app/ui/shadcn/input';
+import { Button } from '@/app/ui/shadcn/button';
+import { 
+  Form,
+  FormField,
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/app/ui/shadcn/form';
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '@/app/ui/shadcn/hover-card';
+
+// own imports
+import { editEmployeeSchema } from "@/app/lib/formSchemas";
+import { PlusIcon, QuestionIcon, DeleteIcon } from '@/app/lib/icons'; 
+
+export default function EditEmployees() {
+
+  // here we would load the shift data from the db into this component, 
+  // but for now we have dummy data
+  const tempEmployees = [
+    {employeeName: 'John Doe', employeeEmail: 'john.doe@example.com', workingDays: 1},
+    {employeeName: 'Jane Doe', employeeEmail: 'jane.doe@example.com', workingDays: 2},
+    {employeeName: 'John Smith', employeeEmail: 'john.smith@example.com', workingDays: 3},
+    {employeeName: 'Jane Smith', employeeEmail: 'jane.smith@example.com', workingDays: 4},
+    {employeeName: 'Bob Bobson', employeeEmail: 'bob.bobson@example.com', workingDays: 5},
+    {employeeName: 'Alice Allison', employeeEmail: 'alice.allison@example.com', workingDays: 6},
+  ]
+
+  // give the form default values
+  const form = useForm<z.infer<typeof editEmployeeSchema>>({
+    resolver: zodResolver(editEmployeeSchema),
+    defaultValues: {
+      employees: tempEmployees
+    }
+  })
+
+  // when we submit the form, edit the db values
+  function onSubmit(values: z.infer<typeof editEmployeeSchema>) {
+    console.log(values);
+  }
+
+  // methods for modifying the shifts
+  const { // definining the methods that this accepts
+    fields: employeeFields,
+    append: appendEmployee,
+    remove: removeEmployee,
+  } = useFieldArray({
+    control: form.control,
+    name: 'employees',
+  });
+
+  const addEmployee = () => {
+    appendEmployee({
+      employeeName: '',
+      employeeEmail: '',
+      workingDays: 1,
+    }); // create a new shift object with our default values
+  };
+  
+  const deleteEmployee = (index: number) => {
+    removeEmployee(index);
+  };
+
+  return (
+    <div className='min-h-screen flex items-start justify-center pt-48'>
+      {/* shadcn form wrapper */}
+      <Form {...form}> 
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+
+        {/* loop over and render the shift fields */}
+        {employeeFields.map((field, index) => (
+        <div // grid container for the row
+          key={field.id}
+          className='grid grid-cols-12 w-full max-w-screen-xl py-2'
+        >
+          {/* name */}
+          <div className='col-span-5 pr-4'>
+            <FormField
+              control={form.control}
+              name={`employees.${index}.employeeName`}
+              render={({ field }) => (
+                <FormItem>
+                  {/* only render the label for the first one */}
+                  {index === 0 && (
+                  <HoverCard openDelay={1} closeDelay={1}>
+                    <HoverCardTrigger>
+                      
+                        <FormLabel className='inline-flex items-center hover:underline'>
+                          Employee Name
+                          <QuestionIcon className='pl-1 text-gray-500' />
+                        </FormLabel>
+                      
+                    </HoverCardTrigger>
+                    <HoverCardContent
+                      side={'top'}
+                      className='text-sm text-gray-500'
+                    >
+                      List the employees that you want to work this week. Enter
+                      their details, and use the + button to add more shifts, or
+                      the delete button to remove extras.
+                    </HoverCardContent>
+                  </HoverCard>
+                  )}
+                  <FormControl>
+                    <Input type='text' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* email */}
+          <div className='col-span-4 pr-4'>
+            <FormField
+              control={form.control}
+              name={`employees.${index}.employeeEmail`}
+              render={({ field }) => (
+                <FormItem>
+                  {index === 0 && (
+                    <FormLabel className=''>
+                      Email
+                    </FormLabel>
+                  )}
+                  <FormControl>
+                    <Input type='email' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Working days */}
+          <div className='col-span-2 pr-4'>
+            <FormField
+              control={form.control}
+              name={`employees.${index}.workingDays`}
+              render={({ field }) => (
+                <FormItem>
+                  {index === 0 && <FormLabel>Days Working</FormLabel>}
+                  <FormControl>
+                    <Input
+                      type='number'
+                      {...field}
+                      onChange={(e) => field.onChange(Number(e.target.value))} // convert the string to a number
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* delete icon for all but the first shift */}
+          {index !== 0 && (
+            <div className='col-span-1'>
+              <Button
+                type='button'
+                size='icon'
+                variant='destructive'
+                onClick={() => deleteEmployee(index)}
+              >
+                <DeleteIcon className='h-6 w-6' />
+              </Button>
+            </div>
+          )}
+
+          {/* plus button to add a new shift and a submit button but only under the last element */}
+          {index === employeeFields.length - 1 && (
+            <>
+              <div className='col-span-11 pt-4 pr-4'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  className='w-full'
+                  onClick={addEmployee}
+                >
+                  <PlusIcon className='h-6 w-6' />
+                </Button>
+              </div>
+
+              <div className='col-span-11 pr-4 pt-4'>
+              <Button className='w-full' type="submit"> Update </Button>
+              </div>
+            </>
+          )}
+
+        </div>
+      ))}
+          
+        </form>
+
+      </Form>
+    </div>
+  );
+}

--- a/app/dashboard/components/edit-shifts.tsx
+++ b/app/dashboard/components/edit-shifts.tsx
@@ -1,0 +1,203 @@
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useFieldArray, useForm } from "react-hook-form";
+
+//shadcn
+import { Input } from '@/app/ui/shadcn/input';
+import { Button } from '@/app/ui/shadcn/button';
+import { 
+  Form,
+  FormField,
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/app/ui/shadcn/form';
+import {
+  HoverCard,
+  HoverCardTrigger,
+  HoverCardContent,
+} from '@/app/ui/shadcn/hover-card';
+
+// own imports
+import { editShiftSchema } from "@/app/lib/formSchemas";
+import { PlusIcon, QuestionIcon, DeleteIcon } from '@/app/lib/icons'; 
+
+export default function EditShifts() {
+
+  // here we would load the shift data from the db into this component, 
+  // but for now we have dummy data
+  const tempShifts = [
+    {shiftName: 'Morning', shiftStartTime: '08:00', shiftEndTime: '16:00'},
+    {shiftName: 'Afternoon', shiftStartTime: '16:00', shiftEndTime: '00:00'},
+    {shiftName: 'Night', shiftStartTime: '00:00', shiftEndTime: '08:00'},
+  ]
+
+  // give the form default values
+  const form = useForm<z.infer<typeof editShiftSchema>>({
+    resolver: zodResolver(editShiftSchema),
+    defaultValues: {
+      shifts: tempShifts
+    }
+  })
+
+  // when we submit the form, edit the db values
+  function onSubmit(values: z.infer<typeof editShiftSchema>) {
+    console.log(values);
+  }
+
+  // methods for modifying the shifts
+  const { // definining the methods that this accepts
+    fields: shiftFields,
+    append: appendShift,
+    remove: removeShift,
+  } = useFieldArray({
+    control: form.control,
+    name: 'shifts',
+  });
+
+  const addShift = () => {
+    appendShift({
+      shiftName: '',
+      shiftStartTime: '00:00',
+      shiftEndTime: '00:00',
+    }); // create a new shift object with our default values
+  };
+  
+  const deleteShift = (index: number) => {
+    removeShift(index);
+  };
+
+  return (
+    <div className='min-h-screen flex items-start justify-center pt-48'>
+      {/* shadcn form wrapper */}
+      <Form {...form}> 
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+
+        {/* loop over and render the shift fields */}
+        {shiftFields.map((field, index) => (
+        <div // grid container for the row
+          key={field.id}
+          className='grid grid-cols-12 w-full max-w-screen-xl py-2'
+        >
+          {/* name */}
+          <div className='col-span-5 pr-4'>
+            <FormField
+              control={form.control}
+              name={`shifts.${index}.shiftName`}
+              render={({ field }) => (
+                <FormItem>
+                  {/* only render the label for the first one */}
+                  {index === 0 && (
+                  <HoverCard openDelay={1} closeDelay={1}>
+                    <HoverCardTrigger>
+                      
+                        <FormLabel className='inline-flex items-center hover:underline'>
+                          Shift Name
+                          <QuestionIcon className='pl-1 text-gray-500' />
+                        </FormLabel>
+                      
+                    </HoverCardTrigger>
+                    <HoverCardContent
+                      side={'top'}
+                      className='text-sm text-gray-500'
+                    >
+                      Enter the shifts that your employees work. Give it a name,
+                      and then enter the time that your shift starts and ends
+                      at. Use the + button to add more shifts, or the delete
+                      button to remove extras.
+                    </HoverCardContent>
+                  </HoverCard>
+                  )}
+                  <FormControl>
+                    <Input type='text' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* start time */}
+          <div className='col-span-3 pr-4'>
+            <FormField
+              control={form.control}
+              name={`shifts.${index}.shiftStartTime`}
+              render={({ field }) => (
+                <FormItem>
+                  {index === 0 && (
+                    <FormLabel className=''>
+                      Start Time
+                    </FormLabel>
+                  )}
+                  <FormControl>
+                    <Input type='time' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* end time */}
+          <div className='col-span-3 pr-4'>
+            <FormField
+              control={form.control}
+              name={`shifts.${index}.shiftEndTime`}
+              render={({ field }) => (
+                <FormItem>
+                  {index === 0 && <FormLabel>End Time</FormLabel>}
+                  <FormControl>
+                    <Input type='time' {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* delete icon for all but the first shift */}
+          {index !== 0 && (
+            <div className='col-span-1'>
+              <Button
+                type='button'
+                size='icon'
+                variant='destructive'
+                onClick={() => deleteShift(index)}
+              >
+                <DeleteIcon className='h-6 w-6' />
+              </Button>
+            </div>
+          )}
+
+          {/* plus button to add a new shift and a submit button but only under the last element */}
+          {index === shiftFields.length - 1 && (
+            <>
+              <div className='col-span-11 pt-4 pr-4'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  className='w-full'
+                  onClick={addShift}
+                >
+                  <PlusIcon className='h-6 w-6' />
+                </Button>
+              </div>
+
+              <div className='col-span-11 pr-4 pt-4'>
+              <Button className='w-full' type="submit"> Update </Button>
+              </div>
+            </>
+          )}
+
+        </div>
+      ))}
+          
+        </form>
+
+      </Form>
+    </div>
+  );
+}

--- a/app/dashboard/employees/page.tsx
+++ b/app/dashboard/employees/page.tsx
@@ -1,5 +1,9 @@
+"use client"
+
+import EditEmployees from "../components/edit-employees";
+
 const EmployeesPage = () => {
-  return <>Employees Page</>;
+  return <EditEmployees />;
 };
 
 export default EmployeesPage;

--- a/app/dashboard/shifts/page.tsx
+++ b/app/dashboard/shifts/page.tsx
@@ -1,5 +1,11 @@
+"use client"
+
+import EditShifts from "../components/edit-shifts";
+
 const ShiftsPage = () => {
-  return <>Shifts Page</>;
+  return (
+    <EditShifts />
+    );
 };
 
 export default ShiftsPage;

--- a/app/lib/formSchemas.tsx
+++ b/app/lib/formSchemas.tsx
@@ -40,6 +40,10 @@ export const editShiftSchema = z.object({
   shifts: z.array(shiftSchema)
 })
 
+export const editEmployeeSchema = z.object({
+  employees: z.array(employeeSchema)
+})
+
 export type FormType = z.infer<typeof formSchema>;
 export type ShiftType = z.infer<typeof shiftSchema>;
 export type Day =

--- a/app/lib/formSchemas.tsx
+++ b/app/lib/formSchemas.tsx
@@ -36,6 +36,10 @@ export const formSchema = z.object({
   numEmployeesAssigned: allShiftsSchema,
 });
 
+export const editShiftSchema = z.object({
+  shifts: z.array(shiftSchema)
+})
+
 export type FormType = z.infer<typeof formSchema>;
 export type ShiftType = z.infer<typeof shiftSchema>;
 export type Day =

--- a/app/lib/icons.tsx
+++ b/app/lib/icons.tsx
@@ -1,0 +1,87 @@
+// plus icon
+export function PlusIcon(props: any) {
+    return (
+        <svg
+            {...props}
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            >
+        <path d='M5 12h14' />
+        <path d='M12 5v14' />
+        </svg>
+    );
+}
+  
+export function DeleteIcon(props: any) {
+    return (
+        <svg
+            {...props}
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+        >
+        <path d='M3 6h18' />
+        <path d='M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6' />
+        <path d='M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2' />
+        </svg>
+    );
+}
+export function QuestionIcon(props: any) {
+    return (
+        <svg
+            {...props}
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+        >
+        <path d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z'></path>
+        </svg>
+    );
+}
+
+export function DayIcon(props: any) {
+return (
+    <svg
+        {...props}
+        xmlns='http://www.w3.org/2000/svg'
+        width='24'
+        height='24'
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        >
+        <rect width='18' height='18' x='3' y='4' rx='2' ry='2' />
+        <line x1='16' x2='16' y1='2' y2='6' />
+        <line x1='8' x2='8' y1='2' y2='6' />
+        <line x1='3' x2='21' y1='10' y2='10' />
+        <path d='M8 14h.01' />
+        <path d='M12 14h.01' />
+        <path d='M16 14h.01' />
+        <path d='M8 18h.01' />
+        <path d='M12 18h.01' />
+        <path d='M16 18h.01' />
+    </svg>
+);
+}

--- a/app/start/components/work-details.tsx
+++ b/app/start/components/work-details.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/app/ui/shadcn/button';
 import { Input } from '@/app/ui/shadcn/input';
 
 import { Day, formSchema } from '../../lib/formSchemas';
+import { QuestionIcon, DayIcon, DeleteIcon, PlusIcon } from '@/app/lib/icons'
 
 type Props = {
   form: UseFormReturn<z.infer<typeof formSchema>>;
@@ -213,94 +214,3 @@ const WorkDetails: React.FC<Props> = ({ form, days }: Props) => {
   );
 };
 export default WorkDetails;
-
-// icons
-// icons for the days open selection
-function DayIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns='http://www.w3.org/2000/svg'
-      width='24'
-      height='24'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='2'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    >
-      <rect width='18' height='18' x='3' y='4' rx='2' ry='2' />
-      <line x1='16' x2='16' y1='2' y2='6' />
-      <line x1='8' x2='8' y1='2' y2='6' />
-      <line x1='3' x2='21' y1='10' y2='10' />
-      <path d='M8 14h.01' />
-      <path d='M12 14h.01' />
-      <path d='M16 14h.01' />
-      <path d='M8 18h.01' />
-      <path d='M12 18h.01' />
-      <path d='M16 18h.01' />
-    </svg>
-  );
-}
-
-// plus icon
-function PlusIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns='http://www.w3.org/2000/svg'
-      width='24'
-      height='24'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='2'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    >
-      <path d='M5 12h14' />
-      <path d='M12 5v14' />
-    </svg>
-  );
-}
-
-function DeleteIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns='http://www.w3.org/2000/svg'
-      width='24'
-      height='24'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='2'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    >
-      <path d='M3 6h18' />
-      <path d='M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6' />
-      <path d='M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2' />
-    </svg>
-  );
-}
-
-function QuestionIcon(props: any) {
-  return (
-    <svg
-      {...props}
-      xmlns='http://www.w3.org/2000/svg'
-      width='24'
-      height='24'
-      viewBox='0 0 24 24'
-      fill='none'
-      stroke='currentColor'
-      strokeWidth='2'
-      strokeLinecap='round'
-      strokeLinejoin='round'
-    >
-      <path d='M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z'></path>
-    </svg>
-  );
-}


### PR DESCRIPTION
- Added edit page with pre-populated temporary dummy data to both /dashboard/employees and /dashboard/shifts
- completely rebuilt the style from the ground up to avoid the styling mistakes made with the original roster form
- moved re-used icons to /lib for use across components

![image](https://github.com/ssdrum/roster-generator-webapp/assets/60195526/1011f323-8e8e-482b-a6fe-04c6a661bbaa)
